### PR TITLE
Split start and start-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For YNAB:
 
 `ENABLE_SCREENSHOTS`: for debugging
 
-Then, you can run a local version by `yarn start` and visiting http://localhost:3000 for triggering the function.
+Then, you can run a local version by `yarn start-dev` and visiting http://localhost:3000 for triggering the function.
 
 ### Cloud Functions
 - Setup a new Cloud Function with:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "db-to-ynab",
   "version": "1.0.0",
-  "main": "local.js",
+  "main": "index.js",
   "license": "MIT",
   "scripts": {
     "start": "node index.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "local.js",
   "license": "MIT",
   "scripts": {
-    "start": "node local.js",
+    "start": "node index.js",
+    "start-dev": "node local.js",
     "lint": "yarn eslint ."
   },
   "dependencies": {


### PR DESCRIPTION
This should make it work locally with `yarn start-dev` and on GCF. Closes #6 .