### PR TITLE
Additional wait

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,6 +176,7 @@ class YNAB extends Browser {
   async goToAccount() {
     console.log('opening account')
     await this.page.waitForSelector('div.nav-accounts')
+    await this.page.waitForSelector(`.nav-account-name.user-data[title="${this.ynabAccountTitle}"]`)
     await this.page.click(`.nav-account-name.user-data[title="${this.ynabAccountTitle}"]`)
     await this.screenshot('ynab-account.png')
   }


### PR DESCRIPTION
I found that GCF would sometimes error out because `div.nav-accounts` would load, but the specific account titles weren't populated yet. This PR adds a wait for the account title.

If the account title doesn't exist, the script times out. Not ideal. Open to better ideas here...