### PR TITLE
Use YNAB API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 download
 *.png
 *.csv
+.vscode

--- a/README.md
+++ b/README.md
@@ -10,10 +10,8 @@ It uses a headless browser to:
 
 - Login to DB
 - Download the CSV of the transactions
-- Convert the CSV to YNAB's format
 - Grab the pending transactions from the page
-- Login to YNAB
-- Do a CSV upload
+- Send the transactions to YNAB using the API.
 
 ## Usage
 
@@ -27,11 +25,11 @@ For DB:
 - `PIN`: PIN code
 
 For YNAB:
-- `USERNAME`: Account username
-- `PASS`: Password
-- `YNAB_ACCOUNT_TITLE`: Account title to sync the transactions into
+- `YNAB_APIKEY`: YNAB "Personal access token". [Here's how to get one](https://api.youneedabudget.com/#personal-access-tokens).
+- `YNAB_BUDGET`: Budget title to sync the transactions into
+- `YNAB_ACCOUNT`: Account title to sync the transactions into
 
-`ENABLE_SCREENSHOTS`: for debugging
+`ENABLE_SCREENSHOTS`: for debugging the headless browser.
 
 Then, you can run a local version by `yarn start-dev` and visiting http://localhost:3000 for triggering the function.
 

--- a/index.js
+++ b/index.js
@@ -244,12 +244,10 @@ exports.doItApi = async (req, res) => {
   const ynab = new ynabAPI.API(YNAB_APIKEY)
 
   try {
-    /**
     await db.setup()
     await db.login()
     await db.goToAccount()
     await db.downloadTransactionFile()
-    */
     console.log("Listing budgets")
     const budgetsResponse = await ynab.budgets.getBudgets()
     const budgets = budgetsResponse.data.budgets
@@ -276,8 +274,7 @@ exports.doItApi = async (req, res) => {
     console.log(`Found target account: ${targetAccount.name}`)
     let targetAccountId = targetAccount.id
     // Parse CSV.
-    const transactionFilePath = '/tmp/88ebe7a4-80d1-4513-951c-48cf8b246c52/Kontoumsaetze_410_551595200_20181126_205500.csv'
-    //const transactionFilePath = db.transactionFilePath
+    const transactionFilePath = db.transactionFilePath
     console.log("Transaction file path = ", transactionFilePath)
     if (!transactionFilePath) {
       reject(new Error('Transactions CSV not found'))

--- a/index.js
+++ b/index.js
@@ -275,9 +275,6 @@ exports.doItApi = async (req, res) => {
     }
     console.log(`Found target account: ${targetAccount.name}`)
     let targetAccountId = targetAccount.id
-    console.log("Getting Payee list")
-    const payeesResponse = await ynab.payees.getPayees(targetBudgetId)
-    const payees = payeesResponse.data.payees
     // Parse CSV.
     const transactionFilePath = '/tmp/88ebe7a4-80d1-4513-951c-48cf8b246c52/Kontoumsaetze_410_551595200_20181126_205500.csv'
     //const transactionFilePath = db.transactionFilePath
@@ -296,18 +293,11 @@ exports.doItApi = async (req, res) => {
       try {
         const transaction = {
           account_id: targetAccountId,
+          payee_name: current['Beg�nstigter / Auftraggeber'],
           date: moment(current.Buchungstag, 'DD.MM.YYYY').format('YYYY-MM-DD'),
           memo: current.Verwendungszweck,
           amount: (Number(current.Soll) + Number(current.Haben)) * Number(100)
         }
-        //console.log("Transaction  base: ", transaction)
-        let payeeId = payees.find(function (payee) {
-          return payee.name.toLowerCase() === current['Beg�nstigter / Auftraggeber'].toLowerCase()
-        })
-        if (!payeeId) {
-          transaction.payee_name = current['Beg�nstigter / Auftraggeber']
-        }
-        transaction.payee_id = payeeId
         array.push(transaction)
       } catch (error) {
         console.dir(error)

--- a/index.js
+++ b/index.js
@@ -293,8 +293,11 @@ exports.doItApi = async (req, res) => {
           date: moment(current.Buchungstag, 'DD.MM.YYYY').format('YYYY-MM-DD'),
           // Memo can only be 100 chars long.
           memo: current.Verwendungszweck.substring(0, 99),
-          // Amount is in "YNAB milliunits" - ie no decimals.
-          amount: (+current.Soll.replace(/[,.]/g, '')) + (+current.Haben.replace(/[,.]/g, '')),
+          // Amount is in "YNAB milliunits" - ie no decimals, *10.
+          amount: (
+            (+current.Soll.replace(/[,.]/g, '')) +
+            (+current.Haben.replace(/[,.]/g, ''))
+          ) * 10,
           cleared: "cleared"
         }
         // Import ID. We'll figure out the last digit once the array is built.

--- a/index.js
+++ b/index.js
@@ -174,14 +174,16 @@ class YNAB {
       return budget.name === budgetTitle
     });
     if (!targetBudget) {
-      console.log("Target budget not found.")
-      return
+      throw "Target budget not found"
     }
     console.log(`Found target budget: ${targetBudget.name}`)
     this.targetBudgetId = targetBudget.id
   }
 
   async findAccount() {
+    if (typeof this.targetBudgetId === 'undefined') {
+      this.findBudget()
+    }
     console.log("Listing Accounts")
     const accountsResponse = await this.ynabAPI.accounts.getAccounts(this.targetBudgetId)
     const accounts = accountsResponse.data.accounts
@@ -190,7 +192,7 @@ class YNAB {
       return account.name === accountTitle
     });
     if (!targetAccount) {
-      console.log("Target account not found.")
+      throw "Target account not found."
       return
     }
     console.log(`Found target account: ${targetAccount.name}`)
@@ -248,6 +250,9 @@ class YNAB {
 
   async submitTransactions() {
     const transactions = this.transactions
+    if (transactions.length === 0) {
+      console.log("No transactions to submit.")
+    }
     console.dir("Uploading transactions: ", transactions)
     // Create transactions
     const transactionsResponse = await this.ynabAPI.transactions.createTransactions(this.targetBudgetId, { transactions })

--- a/index.js
+++ b/index.js
@@ -6,9 +6,6 @@ const uuid = require('uuid/v4')
 const mkdirp = require('mkdirp')
 const expect = require('expect-puppeteer')
 const sleep = require('util').promisify(setTimeout)
-const writeFile = require('util').promisify(fs.writeFile)
-const appendFile = require('util').promisify(fs.appendFile)
-const convertCSV = require('./convertCSV')
 const ynabAPI = require("ynab");
 const moment = require('moment');
 

--- a/index.js
+++ b/index.js
@@ -297,7 +297,8 @@ exports.doItApi = async (req, res) => {
           // Memo can only be 100 chars long.
           memo: current.Verwendungszweck.substring(0, 99),
           // Amount is in "YNAB milliunits" - ie no decimals.
-          amount: (+current.Soll.replace(/[,.]/g, '')) + (+current.Haben.replace(/[,.]/g, ''))
+          amount: (+current.Soll.replace(/[,.]/g, '')) + (+current.Haben.replace(/[,.]/g, '')),
+          cleared: "cleared"
         }
         // Import ID. We'll figure out the last digit once the array is built.
         transaction.import_id = 'YNAB:' + transaction.amount + ':' + transaction.date + ':'

--- a/index.js
+++ b/index.js
@@ -307,16 +307,13 @@ exports.doItApi = async (req, res) => {
   })
 
   try {
-    /*
     await db.setup()
     await db.login()
     await db.goToAccount()
     await db.downloadTransactionFile()
-    */
     await ynab.findBudget()
     await ynab.findAccount()
-    //await ynab.parseCsv(db.transactionFilePath)
-    await ynab.parseCsv('/tmp/88ebe7a4-80d1-4513-951c-48cf8b246c52/Kontoumsaetze_410_551595200_20181126_205500.csv')
+    await ynab.parseCsv(db.transactionFilePath)
     await ynab.submitTransactions()
  } catch (error) {
     console.error(error)

--- a/index.js
+++ b/index.js
@@ -317,7 +317,8 @@ exports.doItApi = async (req, res) => {
     }
     console.dir("Uploading transactions: ", transactions)
     // Create transactions
-
+    const transactionsResponse = await ynab.transactions.createTransactions(targetBudgetId, { transactions })
+    console.log("Transaction response: ", transactionsResponse.status)
  } catch (error) {
     console.error(error)
     res.status(500).send(error)

--- a/index.js
+++ b/index.js
@@ -289,9 +289,9 @@ exports.doItApi = async (req, res) => {
     const linesExceptFirstFive = csvData.split('\n').slice(4).join('\n')
     const buildTransactions = (array, current) => {
       if (!current.Buchungstag) {
-        return;
+        return array;
       }
-      console.log("Processing:", current)
+      // console.log("Processing:", current)
 
       try {
         const transaction = {
@@ -300,7 +300,7 @@ exports.doItApi = async (req, res) => {
           memo: current.Verwendungszweck,
           amount: (Number(current.Soll) + Number(current.Haben)) * Number(100)
         }
-        console.log("Transaction  base: ", transaction)
+        //console.log("Transaction  base: ", transaction)
         let payeeId = payees.find(function (payee) {
           return payee.name.toLowerCase() === current['Beg�nstigter / Auftraggeber'].toLowerCase()
         })
@@ -315,29 +315,11 @@ exports.doItApi = async (req, res) => {
       }
       return array
     }
-    const parseResults = (results) => {
-      const lines = results.data
-      const finalCSV = lines.reduce(buildTransactions, [])
-      results = finalCSV
-      //resolve(Papa.unparse(finalCSV, { quotes: true, newline: '\n' }))
-    }
-
-    const csv = Papa.parse(linesExceptFirstFive, {
-      header: true,
-      complete: parseResults
-    })
-    console.dir("transactions:", csv)
-/**
 		const parseResults = Papa.parse(linesExceptFirstFive, {
-      header: true,
-			complete: function(results) {
-        console.log(results.data)
-				return results.data.reduce(buildTransactions, [])
-			}
+      header: true
     });
-    console.dir("Transactions: ", parseResults)
-*/
-
+    const transactions = parseResults.data.reduce(buildTransactions, [])
+    console.dir("Transactions: ", transactions)
 
  } catch (error) {
     console.error(error)

--- a/index.js
+++ b/index.js
@@ -17,8 +17,6 @@ const {
   BRANCH,
   ACCOUNT,
   PIN,
-  USERNAME,
-  PASS,
   ENABLE_SCREENSHOTS,
   YNAB_APIKEY,
   YNAB_BUDGET,
@@ -262,38 +260,6 @@ class YNAB {
 }
 
 exports.doIt = async (req, res) => {
-  const db = new DB({
-    account: ACCOUNT,
-    branch: BRANCH,
-    pin: PIN,
-    enableScreenshots: ENABLE_SCREENSHOTS
-  })
-  const ynab = new YNAB({
-    username: USERNAME,
-    pass: PASS,
-    ynabAccountTitle: YNAB_ACCOUNT_TITLE,
-    enableScreenshots: ENABLE_SCREENSHOTS
-  })
-  try {
-    await db.setup()
-    await db.login()
-    await db.goToAccount()
-    await db.downloadTransactionFile()
-    await db.downloadPendingTransactions()
-    await db.appendPendingTransactions()
-    await ynab.setup()
-    await ynab.login()
-    await ynab.goToAccount()
-    await ynab.uploadCSV(db.convertedCSVPath)
-  } catch (error) {
-    console.error(error)
-    res.status(500).send(error)
-  }
-
-  res.status(200).send('Success')
-}
-
-exports.doItApi = async (req, res) => {
   const db = new DB({
     account: ACCOUNT,
     branch: BRANCH,

--- a/index.js
+++ b/index.js
@@ -247,6 +247,7 @@ class YNAB {
     const transactions = this.transactions
     if (transactions.length === 0) {
       console.log("No transactions to submit.")
+      return
     }
     // Generate last digit of import_id, set account Id.
     for (var i=0, length=transactions.length; i<length; i++) {

--- a/local.js
+++ b/local.js
@@ -6,4 +6,6 @@ const app = express()
 
 app.get('/', index.doIt)
 
+app.get('/ynab-api', index.doItApi)
+
 app.listen(3000, () => console.log('Visit http://localhost:3000 to trigger the action'))

--- a/local.js
+++ b/local.js
@@ -6,6 +6,4 @@ const app = express()
 
 app.get('/', index.doIt)
 
-app.get('/ynab-api', index.doItApi)
-
 app.listen(3000, () => console.log('Visit http://localhost:3000 to trigger the action'))

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "papaparse": "^4.6.0",
     "puppeteer": "^1.10.0-next.1542094148959",
     "sleep": "^5.2.3",
-    "uuid": "^3.3.2"
+    "uuid": "^3.3.2",
+    "ynab": "^1.9.0"
   },
   "devDependencies": {
     "@verkstedt/eslint-config-verkstedt": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "expect-puppeteer": "^3.5.1",
     "mkdirp": "^0.5.1",
+    "moment": "^2.22.2",
     "ndb": "^1.0.26",
     "papaparse": "^4.6.0",
     "puppeteer": "^1.10.0-next.1542094148959",

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,6 +896,13 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
+  dependencies:
+    iconv-lite "~0.4.13"
+
 end-of-stream@^1.0.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
@@ -1627,7 +1634,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.4.24, iconv-lite@^0.4.4:
+iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -1916,7 +1923,7 @@ is-retry-allowed@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
   integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
 
-is-stream@^1.0.0, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -2310,6 +2317,14 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
 node-pre-gyp@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
@@ -2645,6 +2660,14 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
   integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
+
+portable-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/portable-fetch/-/portable-fetch-3.0.0.tgz#3cbf4aa6dbc5a5734b41c0419c9273313bfd9ad8"
+  integrity sha1-PL9KptvFpXNLQcBBnJJzMTv9mtg=
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -3452,6 +3475,11 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+whatwg-fetch@>=0.10.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+
 which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -3552,3 +3580,10 @@ yauzl@^2.4.2:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+ynab@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/ynab/-/ynab-1.9.0.tgz#0e363aa738e5a3e659c3d397d2df625b47f7ca8b"
+  integrity sha512-0LmsQmiv6dTfXRwA/m3ndbbaGL7WKQdztcHTyZacSGFwS/dGSxMaMIVHh1QgpeGVuZrMNTCGRK/IYbdOX1JzQQ==
+  dependencies:
+    portable-fetch "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2223,6 +2223,11 @@ mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+  integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
YNAB is slow in the headless browser, and causes a lot of timeouts.

Here's a rewrite of the YNAB part of the process which uses the API, instead. This also skips the intermediate CSV conversion step.

I could test this all along with my account, but as of today I don't have any pending transactions so I can't test that. Still, wanted to make you aware and maybe you can test?