### PR TITLE
Download transactions from a fixed period of time

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch YNAB API based sync",
+      "program": "${workspaceFolder}/local.js",
+      "env": {
+        "AWS_REGION":"us-east-1",
+        "ACCOUNT":"5515952",
+        "BRANCH":"410",
+        "PIN":"99617",
+        "YNAB_BUDGET":"Cam and Bryn's budget",
+        "YNAB_ACCOUNT":"DB Personal",
+        "YNAB_APIKEY":"526650b2cff9d645e0b95396144d9cea6c4419ac6bb5eefe5f40bc4d5c2512f3"
+      },
+    }
+  ]
+}

--- a/index.js
+++ b/index.js
@@ -99,6 +99,10 @@ class DB extends Browser {
     await this.screenshot('intro.png')
     await this.page.click(buttonSelector)
     console.log('opening account')
+    await this.page.waitForSelector('#periodFixed')
+    await this.page.click('#periodFixed')
+    const refreshButtonSelector = '#contentContainer div#formId.formContainer form#accountTurnoversForm div.formAction input.button'
+    await this.page.click(refreshButtonSelector)
   }
 
   async downloadPendingTransactions() {


### PR DESCRIPTION
When you log into DB, the default is to show transactions since your last login. Since the script doesn't always complete, this means a lot of skipped transactions.

This PR uses DB's "fixed period" radio button to always download transactions from the last 20 days (default period). YNAB's built in de-duplication will ignore transactions which have already been imported.